### PR TITLE
py3status: pinkybar module to print correct error message

### DIFF
--- a/extra/py3status/pinkybar.py
+++ b/extra/py3status/pinkybar.py
@@ -56,8 +56,9 @@ class Py3status:
         except self.py3.CommandError as ce:
             output = ce.output
             if 'pinkybar' in ce.error:
-                output = ce.error
-                self.py3.error(' '.join(output.splitlines()[0].split()[2:]))
+                for line in ce.error.splitlines():
+                    if 'pinkybar' in line:
+                        self.py3.error(' '.join(line.split()[2:]))
 
         output = output.strip()
 


### PR DESCRIPTION
With `--updates` in the config, py3status `pinkybar` module will always get error output instead of regular output. I'm not sure why, but I tested the command `apt list --upgradable` and got `0` myself.

Anyway, when `pinkybar` want to display error message too, the module will know this and proceed to split up first line (which is empty from `--updates` error message) and cause an exception somewhere.

If you add more arguments in the future, it is possible to get more error messages so this change will look for a line containing `pinkybar` to split  instead of first line. The best solution, I think, may be to see `pinkybar` can not give error messages from scripts or whatever.