### PR TITLE
add f2f: a generic format converter

### DIFF
--- a/extra/py3status/f2f
+++ b/extra/py3status/f2f
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+"""
+This script can convert output from Conky, Python, Bash, Lua, and others
+as long as the string contains generic color format `{color_123456}` that
+would be converted into specialized color format passed by an argument.
+
+Example: conky | ~/f2f --py3status
+Example: echo '{color_#00ffff}Hello {color_#00ff00}world!' | ~/f2f --py3status
+"""
+from sys import argv, stdin, exit
+
+if __name__ == "__main__":
+
+    if '--tmux' in argv:
+        format_string = '#[fg=#{color},bright]{output}'
+    elif '--py3status' in argv:
+        format_string = '[\?color=#{color}&show {output}]'
+    elif '--lemonbar' in argv:
+        format_string = '%{{F#{color}}}{output}'
+    elif '--xmobar' in argv:
+        format_string = '<fc=#{color}>{output}'
+    else:
+        exit('Missing argument')
+
+    output_string = ''
+    for line in stdin:
+        output_string += ''.join(line.splitlines())
+
+    output_list = output_string.split('{color_')[1::1]
+
+    for index, parameter in enumerate(output_list):
+        end = parameter.find('}')
+        color = parameter[:end]
+        output = parameter[1 + end:]
+        output_list[index] = format_string.format(color=color, output=output)
+
+    string = ''.join(output_list).strip()
+    print(string)


### PR DESCRIPTION
As requested, I'm adding this for you to play customization with (conky). Also, I ran into a limitation. We can't add too much with `tmux`. Otherwise, the statusbar disappear. `f2f` not tested with `xmobar`. Thx.

```lua
# ~/.conkyrc
conky.config={
    update_interval=2,
    out_to_console=true,
    out_to_stderr=false,
    total_run_times=1
};
conky.text = [[
 {color_1793d1}OS {color_b294bb}${distribution}
 {color_1793d1}CPU {color_f0c674}${cpu cpu0}
 {color_1793d1}CPU {color_f0c674}${cpu cpu1}% ${cpu cpu2}% ${cpu cpu3}%
 {color_1793d1}MEM {color_f0c674}${mem}/${memmax} (${memperc}%)
 {color_1793d1}HDD {color_f0c674}${fs_used_perc}%
 {color_1793d1}Kernel {color_f0c674}${kernel}
 {color_1793d1}Loadavg {color_f0c674}${loadavg 1}
 {color_1793d1}Uptime {color_f0c674}${uptime}
 {color_1793d1}Freq GHZ {color_f0c674}${freq_g}
 {color_1793d1}Time {color_f0c674}${time %T}
]]
```
```bash
# lemonbar
while true; do echo -n "%{r}" ; conky | ~/f2f --lemonbar ; sleep 2; done | lemonbar -p
```
EDIT: Adding #27 