### PR TITLE
.gitignore: ignore ocaml extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ src/pinky_curses
 __pycache__
 *.info
 *.swp
+src/pinky.cm[i|o]
 
 
 


### PR DESCRIPTION
Don't add `pinkybar --with-ocaml` files to git. 
* `.cmo` object file (bytecode)
* `.cmi` compiled interface file