### PR TITLE
README.md: update rust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ __pycache__
 *.info
 *.swp
 src/pinky.cm[i|o]
+src/pinky.a
 
 
 

--- a/README.md
+++ b/README.md
@@ -886,7 +886,8 @@ but you'll have to edit **src/Makefail.skel** to add the following at the end:
 pinkybar_LDADD = pinky.a
 ```
 ```bash
-~/pinkybar --rust extra/scripts/pinky.rs
+# rust source: extra/scripts/pinky.rs
+~/pinkybar --rust  # no path
 ```
 
 **--with-go**


### PR DESCRIPTION
Correcting the docs to indicate we can't use `--rust` with an argument  :o ... and gitignore.